### PR TITLE
feat: dockerize application stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.env
+.git
+node_modules
+src-site/okuu-control-center/node_modules
+dist
+src-site/okuu-control-center/dist
+logs
+storage
+*.db
+assistant.json
+settings.json
+session.json
+system.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-bookworm-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . ./
+
+EXPOSE 3009
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -116,6 +116,22 @@ For local development with Redis, backend, frontend, and a `llama.cpp` server at
 npm run dev
 ```
 
+### Containerized Application Stack
+
+The host-based development workflow above remains the recommended option for hot reload. To run the backend and frontend in containers instead, while keeping the local OpenAI-compatible LLM at port `8080`, run:
+
+```bash
+docker compose --profile app up --build -d
+```
+
+The frontend is available at `http://yozorawolf-olympic.nord:9000` and proxies API and WebSocket traffic to the backend. Stop the host-based `npm run dev` stack first, or set `FRONTEND_PORT` to use a different port.
+
+Docker containers cannot reach a host LLM through `127.0.0.1`; the Compose profile uses `http://host.docker.internal:8080/v1`. Override that endpoint for another host or machine with `DOCKER_LLM_BASE_URL`:
+
+```bash
+DOCKER_LLM_BASE_URL=http://192.168.1.10:8080/v1 docker compose --profile app up --build -d
+```
+
 ### Semantic Memory
 
 Semantic memory is disabled by default so users do not need a separate embedding model:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,46 @@ services:
       retries: 20
     restart: unless-stopped
 
+  backend:
+    build:
+      context: .
+    profiles:
+      - app
+    env_file:
+      - .env
+    environment:
+      PORT: 3009
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      LLM_BASE_URL: ${DOCKER_LLM_BASE_URL:-http://host.docker.internal:8080/v1}
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    volumes:
+      - ./assistant.json:/app/assistant.json
+      - ./session.json:/app/session.json
+      - ./system.json:/app/system.json
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3009/status').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ./src-site/okuu-control-center
+    profiles:
+      - app
+    ports:
+      - "${FRONTEND_PORT:-9000}:80"
+    depends_on:
+      backend:
+        condition: service_healthy
+    restart: unless-stopped
+
 volumes:
   redis_data:
   ollama_data:

--- a/src-site/okuu-control-center/.dockerignore
+++ b/src-site/okuu-control-center/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.quasar
+.env

--- a/src-site/okuu-control-center/Dockerfile
+++ b/src-site/okuu-control-center/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20-bookworm-slim AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+COPY . ./
+RUN npm run postinstall && npm run build
+
+FROM nginx:1.27-alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist/spa /usr/share/nginx/html
+
+EXPOSE 80

--- a/src-site/okuu-control-center/nginx.conf
+++ b/src-site/okuu-control-center/nginx.conf
@@ -1,0 +1,28 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+    resolver 127.0.0.11 ipv6=off;
+    set $backend http://backend:3009;
+
+    location /socket.io/ {
+        proxy_pass $backend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+
+    location ~ ^/(apiKey|status|whoami|users|gui|memory|config|tools|public)(/|$) {
+        proxy_pass $backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/src-site/okuu-control-center/src/pages/OkuuAIHealthPing.vue
+++ b/src-site/okuu-control-center/src/pages/OkuuAIHealthPing.vue
@@ -27,13 +27,8 @@ onMounted(async () => {
     let connection: Socket;
     try {
         const url = new URL(resolvedUrl);
-        const hostname = url.hostname;
-        let port = '';
-        if (process.env.LOCAL) {
-            // get the port from the environment variable
-            port = process.env.VITE_LOCAL_API_URL ? `:${process.env.VITE_LOCAL_API_URL.split(':')[2]}` : '';
-        }
-        connection = io(`${process.env.LOCAL ? 'ws' : 'wss'}://${hostname}${port}`, {
+        const protocol = process.env.LOCAL ? 'ws' : window.location.protocol === 'https:' ? 'wss' : 'ws';
+        connection = io(`${protocol}://${url.host}`, {
             transports: ['websocket'],
             timeout: 5000,
         });

--- a/src-site/okuu-control-center/src/services/socketio.service.ts
+++ b/src-site/okuu-control-center/src/services/socketio.service.ts
@@ -33,7 +33,8 @@ export class SocketioService {
             // Remove protocol from URL
             url = url.replace(/^https?:\/\//, '');
 
-            this.socket = io(`${process.env.LOCAL ? 'ws' : 'wss'}://${url}`, {
+            const protocol = process.env.LOCAL ? 'ws' : window.location.protocol === 'https:' ? 'wss' : 'ws';
+            this.socket = io(`${protocol}://${url}`, {
                 transports: ['websocket'],
                 timeout: 30000,
                 reconnectionAttempts: 3,
@@ -42,7 +43,7 @@ export class SocketioService {
 
             this.socket.connect();
 
-            console.log('Socket initialized with URL:', `${process.env.LOCAL ? 'ws' : 'wss'}://${url}`);
+            console.log('Socket initialized with URL:', `${protocol}://${url}`);
             this.sessionId = sessionId;
 
             console.log('Socket initialized:', this.sessionId);

--- a/src-site/okuu-control-center/src/utils/okuuai_utils.ts
+++ b/src-site/okuu-control-center/src/utils/okuuai_utils.ts
@@ -6,6 +6,11 @@ export const resolveHostRedirect = async () => {
         return process.env.VITE_LOCAL_API_URL as string;
     }
 
+    // Containerized deployments proxy the API through the frontend origin.
+    if (!process.env.VITE_API_URL) {
+        return window.location.origin;
+    }
+
     // otherwise, resolve the API URL from the environment variable
     try {
         const response = await axios.get(`${process.env.VITE_API_URL as string}`, { maxRedirects: 5 });


### PR DESCRIPTION
## Summary
- add an optional Compose application profile for the backend and production frontend
- proxy frontend API and WebSocket traffic to the internal backend
- retain the host-based hot-reload development workflow
- support OpenAI-compatible LLM and embedding endpoints

## Verification
- `docker compose --profile app config --quiet`
- built backend and frontend images
- validated the frontend Nginx configuration
- `git diff --check origin/master...HEAD`