### PR TITLE
feat: add standalone Whisper transcription service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,17 @@ LLM_MODEL=local-model # Model name sent to the configured inference endpoint
 LLM_TOOL_MODEL=local-model # Optional separate model for tool-selection prompts
 LLM_API_KEY= # Optional bearer token for remote OpenAI-compatible providers
 
+# Standalone speech transcription service
+WHISPER_BASE_URL=http://127.0.0.1:8096
+WHISPER_AUTOSTART=true # Start the service in screen session 'okuuwhis'
+WHISPER_PORT=8096
+WHISPER_HOST=127.0.0.1
+WHISPER_MODEL_NAME=medium
+WHISPER_DEVICE=cpu
+WHISPER_COMPUTE_TYPE=int8
+# WHISPER_PYTHON=/absolute/path/to/python
+# WHISPER_SERVER_SCRIPT=/absolute/path/to/whisper_server.py
+
 # Embeddings / semantic memory
 EMBEDDING_PROVIDER=none # none, openai-compatible, or ollama. none avoids requiring a local embedding model.
 EMBEDDING_BASE_URL=http://127.0.0.1:8081/v1 # OpenAI-compatible embedding endpoint, for example llama.cpp --embedding

--- a/services/whisper-asr/README.md
+++ b/services/whisper-asr/README.md
@@ -1,8 +1,8 @@
 # Standalone Whisper ASR
 
-This module provides the shared OpenAI-compatible transcription service used by OkuuAI and OkuuClaw.
+This module provides the OpenAI-compatible transcription service used by OkuuAI.
 
-OkuuAI starts it automatically in a detached `screen` session named `okuuwhis`. The default endpoint is:
+The server starts automatically in a detached `screen` session named `okuuwhis`. The default endpoint is:
 
 ```text
 http://127.0.0.1:8096/v1/audio/transcriptions

--- a/services/whisper-asr/README.md
+++ b/services/whisper-asr/README.md
@@ -1,0 +1,20 @@
+# Standalone Whisper ASR
+
+This module provides the shared OpenAI-compatible transcription service used by OkuuAI and OkuuClaw.
+
+OkuuAI starts it automatically in a detached `screen` session named `okuuwhis`. The default endpoint is:
+
+```text
+http://127.0.0.1:8096/v1/audio/transcriptions
+```
+
+Configure the model, port, Python executable, and compute backend with the `WHISPER_*` environment variables documented in `.env.example`.
+
+## Setup
+
+```bash
+python3 -m venv services/whisper-asr/.venv
+services/whisper-asr/.venv/bin/pip install -r services/whisper-asr/requirements.txt
+```
+
+The process manager requires GNU Screen. Set `WHISPER_AUTOSTART=false` to run the service through another process manager.

--- a/services/whisper-asr/requirements.txt
+++ b/services/whisper-asr/requirements.txt
@@ -1,0 +1,1 @@
+faster-whisper

--- a/services/whisper-asr/whisper_server.py
+++ b/services/whisper-asr/whisper_server.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Standalone OpenAI-compatible Whisper transcription service."""
+
+import cgi
+import json
+import os
+import tempfile
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from faster_whisper import WhisperModel
+
+
+HOST = os.getenv("WHISPER_HOST", "127.0.0.1")
+PORT = int(os.getenv("WHISPER_PORT", "8096"))
+MODEL_NAME = os.getenv("WHISPER_MODEL_NAME", "medium")
+DEVICE = os.getenv("WHISPER_DEVICE", "cpu")
+COMPUTE_TYPE = os.getenv("WHISPER_COMPUTE_TYPE", "int8")
+
+model = WhisperModel(MODEL_NAME, device=DEVICE, compute_type=COMPUTE_TYPE)
+
+
+class WhisperHandler(BaseHTTPRequestHandler):
+    server_version = "OkuuWhisper/1.0"
+
+    def send_json(self, status, payload):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path == "/health":
+            self.send_json(200, {
+                "ok": True,
+                "model": MODEL_NAME,
+                "device": DEVICE,
+                "compute_type": COMPUTE_TYPE,
+            })
+            return
+        self.send_json(404, {"error": "not found"})
+
+    def do_POST(self):
+        if self.path != "/v1/audio/transcriptions":
+            self.send_json(404, {"error": "not found"})
+            return
+        if "multipart/form-data" not in self.headers.get("Content-Type", ""):
+            self.send_json(400, {"error": "expected multipart/form-data"})
+            return
+
+        form = cgi.FieldStorage(
+            fp=self.rfile,
+            headers=self.headers,
+            environ={"REQUEST_METHOD": "POST", "CONTENT_TYPE": self.headers["Content-Type"]},
+        )
+        upload = form["file"] if "file" in form else None
+        if upload is None or not getattr(upload, "file", None):
+            self.send_json(400, {"error": "audio file is required"})
+            return
+
+        suffix = os.path.splitext(getattr(upload, "filename", "audio.webm"))[1] or ".webm"
+        temp_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_file:
+                temp_file.write(upload.file.read())
+                temp_path = temp_file.name
+
+            segments, info = model.transcribe(temp_path, vad_filter=True)
+            text = " ".join(segment.text.strip() for segment in segments).strip()
+            self.send_json(200, {"text": text, "language": info.language, "duration": info.duration})
+        except Exception as error:
+            self.send_json(500, {"error": str(error)})
+        finally:
+            if temp_path and os.path.exists(temp_path):
+                os.unlink(temp_path)
+
+    def log_message(self, message, *args):
+        if os.getenv("WHISPER_LOGS", "0") == "1":
+            super().log_message(message, *args)
+
+
+if __name__ == "__main__":
+    print(f"Whisper ASR listening on http://{HOST}:{PORT}", flush=True)
+    ThreadingHTTPServer((HOST, PORT), WhisperHandler).serve_forever()

--- a/src/init.ts
+++ b/src/init.ts
@@ -14,6 +14,7 @@ import bcrypt from 'bcrypt';
 import { initRedis } from './langchain/redis';
 import { select } from '@inquirer/prompts';
 import { initOllamaInstance } from './chat';
+import { ensureWhisperServer } from './services/whisper-process.service';
 
 dotenv.config();
 
@@ -95,6 +96,8 @@ export const init = async () =>
 
         // Inference backends are user-managed. Docker/Ollama/model downloads are optional setup steps.
         await initOllamaInstance();
+
+        await ensureWhisperServer();
 
         await initRedis();
 

--- a/src/services/whisper-process.service.ts
+++ b/src/services/whisper-process.service.ts
@@ -1,0 +1,70 @@
+import fs from 'fs';
+import path from 'path';
+import { execFile, spawn } from 'child_process';
+import { promisify } from 'util';
+import { Logger } from '../logger';
+
+const execFileAsync = promisify(execFile);
+const SCREEN_NAME = 'okuuwhis';
+
+const getServerScript = () => process.env.WHISPER_SERVER_SCRIPT || path.join(process.cwd(), 'services', 'whisper-asr', 'whisper_server.py');
+
+const getPython = () => {
+  if (process.env.WHISPER_PYTHON) return process.env.WHISPER_PYTHON;
+  const localVenv = path.join(process.cwd(), 'services', 'whisper-asr', '.venv', 'bin', 'python');
+  return fs.existsSync(localVenv) ? localVenv : 'python3';
+};
+
+const isHealthy = async () => {
+  const baseUrl = (process.env.WHISPER_BASE_URL || 'http://127.0.0.1:8096').replace(/\/$/, '');
+  try {
+    const response = await fetch(`${baseUrl}/health`, { signal: AbortSignal.timeout(2000) });
+    return response.ok;
+  } catch {
+    return false;
+  }
+};
+
+const screenExists = async () => {
+  try {
+    const { stdout } = await execFileAsync('screen', ['-ls']);
+    return stdout.includes(`.${SCREEN_NAME}`);
+  } catch {
+    return false;
+  }
+};
+
+export async function ensureWhisperServer() {
+  if ((process.env.WHISPER_AUTOSTART || 'true').toLowerCase() === 'false') return;
+  if (await isHealthy()) {
+    Logger.DEBUG('Whisper ASR is already healthy.');
+    return;
+  }
+
+  const script = getServerScript();
+  if (!fs.existsSync(script)) {
+    Logger.WARN(`Whisper server script not found: ${script}`);
+    return;
+  }
+
+  if (await screenExists()) {
+    try { await execFileAsync('screen', ['-S', SCREEN_NAME, '-X', 'quit']); } catch { /* stale session */ }
+  }
+
+  const child = spawn('screen', ['-dmS', SCREEN_NAME, getPython(), script], {
+    cwd: path.dirname(script),
+    env: process.env,
+    detached: true,
+    stdio: 'ignore',
+  });
+  child.unref();
+
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    if (await isHealthy()) {
+      Logger.INFO(`Whisper ASR started in screen session '${SCREEN_NAME}'.`);
+      return;
+    }
+  }
+  Logger.WARN(`Whisper ASR did not become healthy. Inspect with: screen -r ${SCREEN_NAME}`);
+}


### PR DESCRIPTION
## Summary
- add a standalone OpenAI-compatible Whisper ASR server under `services/whisper-asr`
- add configurable model, device, compute type, host, and port settings
- start and monitor the service through a detached `screen` session named `okuuwhis`
- ensure the service starts during OkuuAI initialization while allowing autostart to be disabled
- document isolated virtual-environment setup so the service has no OkuuClaw dependency

## Configuration
- default endpoint: `http://127.0.0.1:8096/v1/audio/transcriptions`
- health endpoint: `http://127.0.0.1:8096/health`
- requires GNU Screen and `faster-whisper`
- all runtime settings are exposed through documented `WHISPER_*` variables

## Verification
- Python source compiled successfully
- `npm run build`
- service health endpoint verified on port 8096
- OpenAI-compatible transcription endpoint verified with a generated WAV sample
