### PR TITLE
fix: stabilize document attachments

### DIFF
--- a/src-site/okuu-control-center/src/components/chat/ChatMessage.vue
+++ b/src-site/okuu-control-center/src/components/chat/ChatMessage.vue
@@ -39,6 +39,14 @@
                     <source :src="attachmentSrc" :type="getMimeType(message.file)">
                     Your browser does not support the video tag.
                 </video>
+                <div v-else-if="message.file && !isAttachmentImage && !isAttachmentVideo"
+                    class="file-attachment q-mt-sm">
+                    <q-icon name="description" size="32px" />
+                    <div class="file-attachment-info">
+                        <strong>{{ displayFileName }}</strong>
+                        <span>{{ fileExtension }}</span>
+                    </div>
+                </div>
             </div>
             <div v-if="message.done && message.metadata?.web_search?.sources && message.metadata.web_search.sources.length > 0"
                 class="q-mt-sm row q-gutter-xs">
@@ -185,6 +193,19 @@ const getThumbnail = (image: any) => {
     return image.url;
 };
 
+const fileExtension = computed(() => {
+    const ext = props.message.file?.split('.').pop()?.toUpperCase() || 'FILE';
+    return ext;
+});
+
+const displayFileName = computed(() => {
+    const fileName = props.message.file || '';
+    if ([...fileName].some(char => char.charCodeAt(0) > 255)) return fileName;
+    const bytes = Uint8Array.from(fileName, char => char.charCodeAt(0));
+    const decoded = new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+    return decoded.includes('\uFFFD') ? fileName : decoded;
+});
+
 const getMimeType = (filename: string | undefined) => {
     if (!filename) return 'video/mp4';
     const ext = filename.split('.').pop()?.toLowerCase();
@@ -326,6 +347,28 @@ onMounted(async () => {
 .source-chip:hover {
     transform: translateY(-2px);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.file-attachment {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.45rem 0.75rem;
+    border: 1px solid var(--surface-border);
+    border-radius: 10px;
+    background: var(--surface-1);
+    color: var(--accent-1);
+}
+.file-attachment-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    color: var(--text-muted);
+    font-size: 0.78rem;
+}
+.file-attachment-info strong {
+    color: var(--text-strong);
+    font-size: 0.82rem;
 }
 
 .danbooru-image-container {

--- a/src-site/okuu-control-center/src/stores/session.store.ts
+++ b/src-site/okuu-control-center/src/stores/session.store.ts
@@ -199,7 +199,7 @@ export const useSessionStore = defineStore('session', {
             const existingMessage = session.messages.find(m =>
                 (message.clientMessageId && m.clientMessageId === message.clientMessageId) ||
                 (message.memoryKey && m.memoryKey === message.memoryKey) ||
-                (!message.memoryKey && !m.memoryKey && m.timestamp === message.timestamp)
+                (m.sessionId === message.sessionId && m.timestamp === message.timestamp)
             );
             if (existingMessage) {
                 const messageIndex = session.messages.indexOf(existingMessage);

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -28,6 +28,7 @@ export interface ChatMessage {
     stream?: boolean;
     thinking?: string;
     memoryKey?: string;
+    clientMessageId?: string;
     file?: string;
     attachment?: string;
     metadata?: {
@@ -114,6 +115,9 @@ async function buildPrompt(msg: ChatMessage, includeTools: boolean = true, tools
         systemPrompt = systemPrompt.replace(/{{mention}}/g, '');
     }
 
+    const attachmentSection = msg.attachment && msg.file && !imageExts.includes(msg.file.split('.').pop()?.toLowerCase() || '')
+        ? `\n\nAttached file (${msg.file}):\n${msg.attachment.length > 8000 ? msg.attachment.slice(0, 8000) + '\n... (truncated)' : msg.attachment}` : '';
+
     const prompt = `
 System:
 ${systemPrompt}${toolsSection}
@@ -124,7 +128,7 @@ ${memoryContext || 'None'}
 Conversation so far:
 ${history}
 
-User (${msg.user}): ${msg.message}
+User (${msg.user}): ${msg.message}${attachmentSection}
 Okuu:
     `.trim();
 

--- a/src/controllers/memory.controller.ts
+++ b/src/controllers/memory.controller.ts
@@ -98,7 +98,7 @@ export const createMemoryRecord = async (req: Request, res: Response) => {
     Logger.DEBUG(`File type: ${file.mimetype}`);
     //Logger.DEBUG('File data: '+file.data);
     const allowedExtensions = ['json', 'docx', 'txt', 'pdf', 'csv', ...imageExts];
-    const extension = file.name.split('.').pop() || '';
+    const extension = file.name.split('.').pop()?.toLowerCase() || '';
     if (!allowedExtensions.includes(extension)) {
         res.status(400).send(`Invalid file type. Allowed types: ${allowedExtensions.join(', ')}`);
         return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,8 @@ export let io: Server;
 
         // File upload middleware
         app.use(fileUpload({
-            limits: { fileSize: 5 * 1024 * 1024 }, // 5MB file size limit
+            limits: { fileSize: 25 * 1024 * 1024 },
+            abortOnLimit: true,
             useTempFiles: false,
             debug: false,
         }));

--- a/src/langchain/memory/storage.ts
+++ b/src/langchain/memory/storage.ts
@@ -8,6 +8,12 @@ import { PdfReader } from 'pdfreader';
 const stroragePath = path.join(process.cwd(), 'storage');
 const imageExts = ['jpg', 'jpeg', 'png', 'gif', 'svg', 'webp'];
 
+const normalizeUploadFileName = (fileName: string) => {
+    if ([...fileName].some(char => char.charCodeAt(0) > 255)) return fileName;
+    const decoded = Buffer.from(fileName, 'latin1').toString('utf8');
+    return decoded.includes('\uFFFD') ? fileName : decoded;
+};
+
 const createStorageFolder = () => {
     if (!fs.existsSync(stroragePath)) {
         fs.mkdirSync(stroragePath);
@@ -33,7 +39,7 @@ const checkFileExists = (fileName: string): string => {
 };
 
 export const saveFileToStorage = async (file: UploadedFile): Promise<string | false> => {
-    const fileName = checkFileExists(file.name);
+    const fileName = checkFileExists(normalizeUploadFileName(file.name));
     const filePath = path.join(stroragePath, fileName);
     if(!doesStorageFolderExist()) {
         createStorageFolder();
@@ -66,22 +72,18 @@ export const loadFileContentFromStorage = async (fileName: string): Promise<stri
             attachment += file.toString();
             Logger.DEBUG(`Text content: ${file}`);
         } else if (extension === 'pdf') {
-            const pdfReader = new PdfReader();
-            pdfReader.parseBuffer(file, (err: any, item: any) => {
-                if (err) {
-                    Logger.ERROR(`Error parsing PDF file: ${err}`);
-                    throw err;
-                }
-                if (item && item.text) {
-                    attachment += item.text + '\n';
-                }
-                if (!item) {
-                    // End of file
-                    // Process the content as needed
-                    console.log('File content:', attachment);
-                    // Save the content to memory
-                    // await memoryService.saveMemory(content);
-                }
+            attachment = await new Promise<string>((resolve, reject) => {
+                const pdfReader = new PdfReader();
+                let text = '';
+                pdfReader.parseBuffer(file, (err: any, item: any) => {
+                    if (err) {
+                        reject(err);
+                    } else if (!item) {
+                        resolve(text);
+                    } else if (item.text) {
+                        text += item.text + '\n';
+                    }
+                });
             });
         } else if (extension === 'csv') {
             attachment += file.toString();


### PR DESCRIPTION
## Summary
- render non-image attachments in sent chat messages and repair mojibake filenames
- include extracted document text in the model prompt and merge attachment echoes without duplication
- await PDF parsing so malformed files cannot crash the backend
- raise the upload limit to 25 MB and reject oversized files instead of silently truncating them
- normalize multipart filenames to UTF-8 and validate extensions case-insensitively
- resolve OpenAI-compatible `local-model` placeholders to the configured provider model or its first advertised model
- keep main and tool model selection aligned when both use the placeholder

## Verification
- `npm run build`
- `npm run lint && npm run build` in `src-site/okuu-control-center`
- OpenAI-compatible resolution returned `Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive-Q6_K_P.gguf` for main and tool models
- `git diff --check`
