### PR TITLE
fix: resolve OpenAI-compatible model selection

### DIFF
--- a/src/controllers/config.controller.ts
+++ b/src/controllers/config.controller.ts
@@ -1,7 +1,7 @@
 import { Core } from '@src/core';
 import { Logger } from '@src/logger';
 import { updateAssistantConfigJSON } from '@src/o_utils';
-import { getAvailableModels } from '@src/llm';
+import { getAvailableModels, resolveMainModel } from '@src/llm';
 import { Request, Response } from 'express';
 import fileUpload from 'express-fileupload';
 import fs from 'fs';
@@ -87,7 +87,9 @@ export const setOkuuModel = async (req: Request, res: Response) => {
 
 export const getDownloadedModels = async (req: Request, res: Response) => {
     try {
-        res.status(200).send({ models: await getAvailableModels() });
+        const models = await getAvailableModels();
+        await resolveMainModel(models);
+        res.status(200).send({ models });
     } catch (error) {
         Logger.ERROR(`Failed to fetch available models: ${error instanceof Error ? error.message : error}`);
         res.status(502).send({ error: 'Unable to fetch models from the configured provider.' });

--- a/src/init.ts
+++ b/src/init.ts
@@ -15,6 +15,7 @@ import { initRedis } from './langchain/redis';
 import { select } from '@inquirer/prompts';
 import { initOllamaInstance } from './chat';
 import { ensureWhisperServer } from './services/whisper-process.service';
+import { resolveMainModel } from './llm';
 
 dotenv.config();
 
@@ -96,6 +97,13 @@ export const init = async () =>
 
         // Inference backends are user-managed. Docker/Ollama/model downloads are optional setup steps.
         await initOllamaInstance();
+
+        try {
+            await resolveMainModel();
+            Logger.INFO(`Resolved main model: ${Core.model_name}`);
+        } catch (error) {
+            Logger.WARN(`Unable to resolve provider models during startup: ${error}`);
+        }
 
         await ensureWhisperServer();
 

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -78,6 +78,23 @@ export const getAvailableModels = async (): Promise<{ name: string; multimodal: 
         .filter((model: { name: unknown }) => typeof model.name === 'string' && model.name.length > 0);
 };
 
+export const resolveMainModel = async (availableModels?: { name: string; multimodal: boolean }[]) => {
+    if (isOllamaProvider()) return Core.model_name;
+
+    const models = availableModels || await getAvailableModels();
+    if (!models.length) return Core.model_name;
+
+    const configuredModel = Core.model_name;
+    const configuredExists = models.some(model => model.name === configuredModel);
+    if (!configuredExists || configuredModel === 'local-model') {
+        Core.model_name = models[0].name;
+    }
+    if (!Core.tool_model_name || Core.tool_model_name === 'local-model') {
+        Core.tool_model_name = Core.model_name;
+    }
+    return Core.model_name;
+};
+
 export const embedText = async (input: string): Promise<number[]> => {
     const provider = getEmbeddingProvider();
     const model = process.env.EMBEDDING_MODEL || 'nomic-embed-text';


### PR DESCRIPTION
## Summary
- preserve a configured model when it is advertised by the OpenAI-compatible provider
- replace the `local-model` placeholder or a missing model with the provider's first advertised model
- align the tool model with the resolved main model when it also uses the placeholder
- resolve models during startup and again when the frontend refreshes the provider model list
- keep startup resilient when the external provider is temporarily unavailable

## Verification
- `npm run build`
- `npm run lint` in `src-site/okuu-control-center`
- live provider resolution selected `Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive-Q6_K_P.gguf` for both main and tool models
- `git diff --check`
