### PR TITLE
feat: add private Meshnet HTTPS access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,13 @@ OLLAMA_PORT=7009 # Port for the Ollama server
 OLLAMA_DEFAULT_MODEL=llama3 # Default model for Ollama if none is specified during config
 
 # Network (Optional - For remote access)
+MESHNET_HOST=your-device.nord # Nord Meshnet hostname used by the private HTTPS certificate
+MESHNET_IP= # Optional Meshnet IP included in the certificate
+FRONTEND_HTTPS_PORT=9443 # Set to 443 for https://your-device.nord without a port
+MESHNET_UPSTREAM=frontend:80 # HTTPS proxy target for the Docker application stack
+MESHNET_DEV_UPSTREAM=127.0.0.1:9000 # HTTPS proxy target when the frontend runs via npm run dev
+MESHNET_BACKEND_UPSTREAM=backend:3009 # Backend target for the Docker application stack
+MESHNET_DEV_BACKEND_UPSTREAM=127.0.0.1:3009 # Backend target when running npm run dev
 WEB_URL=http://nginxproxymanager.com # Web URL for the nginx proxy manager interface
 PROXY_URL= # If specified, won't update anything in nginx proxy manager
 PROXY_EMAIL= # Email for the Nginx Proxy Manager

--- a/README.md
+++ b/README.md
@@ -40,6 +40,57 @@ docker compose --profile app up --build -d
 
 The frontend is available at `http://yozorawolf-olympic.nord:9000` and proxies API and WebSocket traffic to the backend. Stop the host-based `npm run dev` stack first, or set `FRONTEND_PORT` to use a different port.
 
+### Private HTTPS over Meshnet
+
+Browser screen capture requires a trusted HTTPS origin. For private Meshnet access, OkuuAI includes an optional TLS proxy backed by a private certificate authority. It does not expose OkuuAI to the public internet.
+
+Generate a certificate for the server's Nord hostname. Including the Meshnet IP is optional but allows access by either name or address:
+
+```bash
+./scripts/setup-meshnet-https.sh yozorawolf-olympic.nord 100.64.0.10
+```
+
+The generated files are stored under the ignored `storage/meshnet-tls/` directory. Keep `ca.key` and `server.key` private. Copy only `storage/meshnet-tls/ca.crt` to each personal client device and install it as a trusted root certificate:
+
+Linux (Debian/Ubuntu):
+
+```bash
+sudo cp ca.crt /usr/local/share/ca-certificates/okuuai-meshnet.crt
+sudo update-ca-certificates
+```
+
+macOS:
+
+```bash
+sudo security add-trusted-cert -d -r trustRoot \
+  -k /Library/Keychains/System.keychain ca.crt
+```
+
+Windows (Administrator PowerShell):
+
+```powershell
+certutil -addstore -f Root ca.crt
+```
+
+Restart the browser after trusting the CA, then start the HTTPS profile:
+
+Docker application stack:
+
+```bash
+docker compose --profile app --profile meshnet-https up --build -d
+```
+
+Host development with `npm run dev`:
+
+```bash
+docker compose --profile meshnet-https-dev up -d meshnet-https-dev
+npm run dev
+```
+
+The development profile uses host networking so the proxy can reach Quasar without opening the Docker bridge in the host firewall. Do not run `meshnet-https` and `meshnet-https-dev` simultaneously because they use the same HTTPS port.
+
+Open `https://yozorawolf-olympic.nord:9443`. Set `FRONTEND_HTTPS_PORT=443` in `.env` if port 443 is available and you prefer `https://yozorawolf-olympic.nord`. The original HTTP endpoint remains available unless disabled separately.
+
 Docker containers cannot reach a host LLM through `127.0.0.1`; the Compose profile uses `http://host.docker.internal:8080/v1`. Override that endpoint for another host or machine with `DOCKER_LLM_BASE_URL`:
 
 ```bash

--- a/deploy/meshnet/default.conf.template
+++ b/deploy/meshnet/default.conf.template
@@ -1,0 +1,42 @@
+server {
+    listen ${MESHNET_LISTEN_PORT} ssl;
+    server_name _;
+
+    ssl_certificate /etc/nginx/tls/server.crt;
+    ssl_certificate_key /etc/nginx/tls/server.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_session_cache shared:TLS:10m;
+    ssl_session_timeout 1d;
+
+    location /socket.io/ {
+        proxy_pass http://${MESHNET_BACKEND_UPSTREAM};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+
+    location ~ ^/(apiKey|status|whoami|users|gui|memory|config|tools|admin|audio|modules|public)(/|$) {
+        proxy_pass http://${MESHNET_BACKEND_UPSTREAM};
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    location / {
+        proxy_pass http://${MESHNET_UPSTREAM};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+}
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -72,6 +72,44 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  meshnet-https:
+    image: nginx:1.27-alpine
+    container_name: okuuai_meshnet_https
+    profiles:
+      - meshnet-https
+    ports:
+      - "${FRONTEND_HTTPS_PORT:-9443}:9443"
+    environment:
+      MESHNET_UPSTREAM: "${MESHNET_UPSTREAM:-frontend:80}"
+      MESHNET_BACKEND_UPSTREAM: "${MESHNET_BACKEND_UPSTREAM:-backend:3009}"
+      MESHNET_LISTEN_PORT: "9443"
+      NGINX_ENVSUBST_FILTER: "^(MESHNET_UPSTREAM|MESHNET_BACKEND_UPSTREAM|MESHNET_LISTEN_PORT)$"
+    volumes:
+      - ./deploy/meshnet/default.conf.template:/etc/nginx/templates/default.conf.template:ro
+      - ./storage/meshnet-tls:/etc/nginx/tls:ro
+    depends_on:
+      backend:
+        condition: service_healthy
+      frontend:
+        condition: service_started
+    restart: unless-stopped
+
+  meshnet-https-dev:
+    image: nginx:1.27-alpine
+    container_name: okuuai_meshnet_https_dev
+    profiles:
+      - meshnet-https-dev
+    network_mode: host
+    environment:
+      MESHNET_UPSTREAM: "${MESHNET_DEV_UPSTREAM:-127.0.0.1:9000}"
+      MESHNET_BACKEND_UPSTREAM: "${MESHNET_DEV_BACKEND_UPSTREAM:-127.0.0.1:3009}"
+      MESHNET_LISTEN_PORT: "${FRONTEND_HTTPS_PORT:-9443}"
+      NGINX_ENVSUBST_FILTER: "^(MESHNET_UPSTREAM|MESHNET_BACKEND_UPSTREAM|MESHNET_LISTEN_PORT)$"
+    volumes:
+      - ./deploy/meshnet/default.conf.template:/etc/nginx/templates/default.conf.template:ro
+      - ./storage/meshnet-tls:/etc/nginx/tls:ro
+    restart: unless-stopped
+
 volumes:
   redis_data:
   ollama_data:

--- a/scripts/setup-meshnet-https.sh
+++ b/scripts/setup-meshnet-https.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST_NAME="${1:-${MESHNET_HOST:-}}"
+MESHNET_IP="${2:-${MESHNET_IP:-}}"
+TLS_DIR="${MESHNET_TLS_DIR:-storage/meshnet-tls}"
+
+if [[ -z "$HOST_NAME" ]]; then
+  echo "Usage: $0 <meshnet-hostname> [meshnet-ip]"
+  echo "Example: $0 yozorawolf-olympic.nord 100.64.0.10"
+  exit 1
+fi
+
+if [[ ! "$HOST_NAME" =~ ^[A-Za-z0-9.-]+$ ]]; then
+  echo "Invalid Meshnet hostname: $HOST_NAME" >&2
+  exit 1
+fi
+
+if [[ -n "$MESHNET_IP" && ! "$MESHNET_IP" =~ ^[0-9A-Fa-f:.]+$ ]]; then
+  echo "Invalid Meshnet IP address: $MESHNET_IP" >&2
+  exit 1
+fi
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "OpenSSL is required to generate the local certificates." >&2
+  exit 1
+fi
+
+mkdir -p "$TLS_DIR"
+chmod 700 "$TLS_DIR"
+
+CA_KEY="$TLS_DIR/ca.key"
+CA_CERT="$TLS_DIR/ca.crt"
+SERVER_KEY="$TLS_DIR/server.key"
+SERVER_CERT="$TLS_DIR/server.crt"
+SERVER_CSR="$TLS_DIR/server.csr"
+EXT_FILE="$TLS_DIR/server.ext"
+
+if [[ ! -f "$CA_KEY" || ! -f "$CA_CERT" ]]; then
+  openssl genrsa -out "$CA_KEY" 4096
+  openssl req -x509 -new -sha256 -days 3650 \
+    -key "$CA_KEY" \
+    -out "$CA_CERT" \
+    -subj "/CN=OkuuAI Meshnet Local CA" \
+    -addext "basicConstraints=critical,CA:TRUE" \
+    -addext "keyUsage=critical,keyCertSign,cRLSign"
+fi
+
+cat > "$EXT_FILE" <<EOF
+basicConstraints=critical,CA:FALSE
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=@alt_names
+
+[alt_names]
+DNS.1=$HOST_NAME
+EOF
+
+if [[ -n "$MESHNET_IP" ]]; then
+  printf 'IP.1=%s\n' "$MESHNET_IP" >> "$EXT_FILE"
+fi
+
+openssl genrsa -out "$SERVER_KEY" 2048
+openssl req -new -sha256 \
+  -key "$SERVER_KEY" \
+  -out "$SERVER_CSR" \
+  -subj "/CN=$HOST_NAME"
+openssl x509 -req -sha256 -days 825 \
+  -in "$SERVER_CSR" \
+  -CA "$CA_CERT" \
+  -CAkey "$CA_KEY" \
+  -CAcreateserial \
+  -out "$SERVER_CERT" \
+  -extfile "$EXT_FILE"
+
+rm -f "$SERVER_CSR" "$EXT_FILE"
+chmod 600 "$CA_KEY" "$SERVER_KEY"
+chmod 644 "$CA_CERT" "$SERVER_CERT"
+
+cat <<EOF
+
+Meshnet TLS certificate created for $HOST_NAME.
+
+Keep private:
+  $CA_KEY
+  $SERVER_KEY
+
+Install this certificate as a trusted root CA on each client device:
+  $CA_CERT
+
+Then start OkuuAI with:
+  docker compose --profile app --profile meshnet-https up --build -d
+
+Open:
+  https://$HOST_NAME:${FRONTEND_HTTPS_PORT:-9443}
+EOF

--- a/src-site/okuu-control-center/nginx.conf
+++ b/src-site/okuu-control-center/nginx.conf
@@ -15,7 +15,7 @@ server {
         proxy_set_header Host $host;
     }
 
-    location ~ ^/(apiKey|status|whoami|users|gui|memory|config|tools|public)(/|$) {
+    location ~ ^/(apiKey|status|whoami|users|gui|memory|config|tools|admin|audio|modules|public)(/|$) {
         proxy_pass $backend;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/src-site/okuu-control-center/src/services/socketio.service.ts
+++ b/src-site/okuu-control-center/src/services/socketio.service.ts
@@ -29,13 +29,11 @@ export class SocketioService {
         }
 
         try {
-            let url = await resolveHostRedirect();
+            const url = await resolveHostRedirect();
             if (!url) throw new Error('Invalid URL');
-            // Remove protocol from URL
-            url = url.replace(/^https?:\/\//, '');
-
-            const protocol = process.env.LOCAL ? 'ws' : window.location.protocol === 'https:' ? 'wss' : 'ws';
-            this.socket = io(`${protocol}://${url}`, {
+            const socketUrl = new URL(url, window.location.origin);
+            socketUrl.protocol = socketUrl.protocol === 'https:' ? 'wss:' : 'ws:';
+            this.socket = io(socketUrl.origin, {
                 transports: ['websocket'],
                 auth: { token: localStorage.getItem('token') },
                 timeout: 30000,
@@ -45,7 +43,7 @@ export class SocketioService {
 
             this.socket.connect();
 
-            console.log('Socket initialized with URL:', `${protocol}://${url}`);
+            console.log('Socket initialized with URL:', socketUrl.origin);
             this.sessionId = sessionId;
 
             console.log('Socket initialized:', this.sessionId);

--- a/src-site/okuu-control-center/src/utils/okuuai_utils.ts
+++ b/src-site/okuu-control-center/src/utils/okuuai_utils.ts
@@ -1,6 +1,12 @@
 import axios from 'axios';
 
 export const resolveHostRedirect = async () => {
+    // HTTPS deployments proxy API and WebSocket traffic through the same origin.
+    // Falling back to a configured HTTP API would be blocked as mixed content.
+    if (window.location.protocol === 'https:') {
+        return window.location.origin;
+    }
+
     // if LOCAL flag is set, return the local API URL
     if (process.env.LOCAL) {
         return process.env.VITE_LOCAL_API_URL as string;


### PR DESCRIPTION
## Summary
- add an opt-in private-CA HTTPS proxy for direct NordVPN Meshnet access
- support both the Docker application stack and host-development frontend
- proxy API and Socket.IO traffic through the secure frontend origin to avoid mixed content
- add certificate generation, client trust instructions, and configurable Meshnet endpoints

## Testing
- generated and verified a certificate for the Meshnet DNS name and IP SAN
- validated both Nginx proxy profiles and Docker Compose configuration
- verified HTTPS `/status` and Socket.IO handshake through the live host-development proxy
- `npm test`
- frontend lint and production build

## Dependency
Stacked on #25 because browser screen capture is introduced by Conversation Mode.